### PR TITLE
Table colors

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -27,16 +27,16 @@ The AppMap recording client enables an application to dynamically record and emi
      <thead>
         <tr>
            <th class="no-border"></th>
-           <th colspan="4">Application tracing methods</th>
+           <th colspan="4" class="dark-header">Application tracing methods</th>
         </tr>
      </thead>
      <tbody>
         <tr>
            <td class="no-border"></td>
-           <td>Performance profiler</td>
-           <td>APM</td>
-           <td>Logging</td>
-           <td>AppMap</td>
+           <td class="dusky-td">Performance profiler</td>
+           <td class="dusky-td">APM</td>
+           <td class="dusky-td">Logging</td>
+           <td class="dusky-td">AppMap</td>
         </tr>
         <tr>
            <td>Level of detail</td>
@@ -46,7 +46,7 @@ The AppMap recording client enables an application to dynamically record and emi
            <td>Medium</td>
         </tr>
         <tr>
-           <td class="green-cell">Commands received</td>
+           <td>Commands received</td>
            <td class="green-cell">Yes</td>
            <td class="green-cell">Yes</td>
            <td class="green-cell">Yes</td>

--- a/_sass/appland-theme.scss
+++ b/_sass/appland-theme.scss
@@ -338,7 +338,6 @@ a {
     }
     .dusky-td {
       background-color: #dde2ef
-      font-weight: bold;
     }
   }
 

--- a/_sass/appland-theme.scss
+++ b/_sass/appland-theme.scss
@@ -334,9 +334,11 @@ a {
     }
     .dark-header {
       background-color: #232b3f;
+      color: $white;
     }
     .dusky-td {
       background-color: #dde2ef
+      font-weight: bold;
     }
   }
 

--- a/_sass/appland-theme.scss
+++ b/_sass/appland-theme.scss
@@ -332,6 +332,12 @@ a {
       padding: 0.5rem 1rem;
       border: 1px solid $table-border-color;
     }
+    .dark-header {
+      background-color: #232b3f;
+    }
+    .dusky-td {
+      background-color: #dde2ef
+    }
   }
 
   dl {

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -15,7 +15,7 @@ $appland-text: $gray4;
 $white: lighten($appland-text,35); // aaaalmost pure white. softened a bit.
 
 // table cells
-$affirmative-green: #d2ecc4;
+$affirmative-green: #60b7b240;
 $maybe-yellow: #eaecc4;
 
 // Breakpoints


### PR DESCRIPTION
-- Table uses AppLand colors
Before:
![Screenshot from 2020-10-16 18-14-14](https://user-images.githubusercontent.com/1229326/96313241-77608200-0fdb-11eb-8d4b-3c6f37fba017.png)
After:
![Screenshot from 2020-10-16 18-14-01](https://user-images.githubusercontent.com/1229326/96313253-80e9ea00-0fdb-11eb-90a9-d8e028011199.png)

