### PR TITLE
Add corporate header back in

### DIFF
--- a/_includes/appland-platform.html
+++ b/_includes/appland-platform.html
@@ -1,10 +1,9 @@
-<h1 class="section-header"> The AppLand Framework</h1>
 <div class="section-content">
   <p>
-    Software tools such as performance profilers, APMs, and log aggregators all provide some information about the behavior of code; but none are dedicated to helping developers inspect and optimize end-to-end code and data flows. The AppLand Framework provides comprehensive information about the internal and external design of your code, recorded into simple JSON files called AppMaps. These AppMap files can be easily obtained by executing test cases or by interactively recording a live, running application. You can use AppMap recordings to generate insightful visualizations and analytics, share with your team, and optimize your software architecture.
+    <img src="/assets/img/pages/appmap-diagram.svg" alt="Appmap diagram">
   </p>
   <p>
-    <img src="/assets/img/pages/appmap-diagram.svg" alt="Appmap diagram">
+    Software tools such as performance profilers, APMs, and log aggregators all provide some information about the behavior of code; but none are dedicated to helping developers inspect and optimize end-to-end code and data flows. The AppLand Framework provides comprehensive information about the internal and external design of your code, recorded into simple JSON files called AppMaps. These AppMap files can be easily obtained by executing test cases or by interactively recording a live, running application. You can use AppMap recordings to generate insightful visualizations and analytics, share with your team, and optimize your software architecture.
   </p>
   <h3 id="data-format-specification">Data format specification</h3>
   <p>

--- a/_includes/corporate_header.html
+++ b/_includes/corporate_header.html
@@ -1,0 +1,7 @@
+
+<nav id="corp-nav">
+  <ul>
+    <li><a href="https://app.land">
+        <img src="/assets/img/appland-logo-sharp.svg"/></a></li>
+  </ul>
+</nav>

--- a/_includes/hero-content.html
+++ b/_includes/hero-content.html
@@ -1,7 +1,7 @@
 <div class="hero-content">
-  <h1 class="project-name">AppLand</h1>
+  <h1 class="project-name">AppLand framework</h1>
   <p class="project-tagline">
-    A framework to record, analyze, and optimize end-to-end code and data flows.
+    Record, analyze, and optimize end-to-end code and data flows.
   </p>
   <p class="project-tagline">
     Our goal at AppLand is to help code "speak for itself." We’re a group of passionate engineers and architects

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     <div id="applandoss">
       <!-- header -->
       <header class="page-header">
+        {% include corporate_header.html %}
         {% include navigation.html %}
         {% if page.category=="home" %}
           {% include hero-content.html %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -4,9 +4,6 @@ title: AppMap
 permalink: /
 category: home
 ---
-
-{% include oss-projects.html %}
-
-{% include code-gallery-preview.html %}
-
 {% include appland-platform.html %}
+{% include oss-projects.html %}
+{% include code-gallery-preview.html %}

--- a/_sass/_navs.scss
+++ b/_sass/_navs.scss
@@ -91,6 +91,21 @@ h1 {
   }
 }
 
+#corp-nav {
+  background-color: black;
+  padding: 1rem;
+  ul {
+    margin-left: auto;
+    @include small {
+      margin-right: auto;
+    }
+  }
+  img {
+    width: 8rem;
+  }
+
+}
+
 @include small {
   .blog-post-list .blog-post {
      flex-direction: column;


### PR DESCRIPTION
This PR...
-- adds the corporate header
-- shifts the 'AppLand framwork' section up to be under the hero
-- Changes the page heading from 'AppLand' to 'AppLand framework' 

before:
![before](https://user-images.githubusercontent.com/1229326/99856321-b9d72a80-2b56-11eb-8c07-2050f0049bf0.png)
after:
![after](https://user-images.githubusercontent.com/1229326/99856334-c0fe3880-2b56-11eb-9a7f-112c70ca295a.png)

