### PR TITLE
header opens appland.com in new tab

### DIFF
--- a/_includes/corporate_header.html
+++ b/_includes/corporate_header.html
@@ -1,7 +1,7 @@
 
 <nav id="corp-nav">
   <ul>
-    <li><a href="https://app.land">
+    <li><a href="https://appland.com" target="_blank">
         <img src="/assets/img/appland-logo-sharp.svg"/></a></li>
   </ul>
 </nav>


### PR DESCRIPTION
Appland logo header opens appland.com (instead of app.land) in a new tab.

https://github.com/applandorg/applandorg.github.io/issues/34