### PR TITLE
Add attribute based event tracking

### DIFF
--- a/_includes/hero-content.html
+++ b/_includes/hero-content.html
@@ -4,12 +4,20 @@
     Record, analyze, and optimize end-to-end code and data flows.
   </p>
   <p class="project-tagline">
-    Our goal at AppLand is to help code "speak for itself." We’re a group of passionate engineers and architects
-    aiming to drive innovation in software architecture and design. Software is oftentimes complex and its nuances
-    can be difficult to communicate efficiently. We'd like to change that.
+    Our goal at AppLand is to help code "speak for itself." We’re a group of
+    passionate engineers and architects aiming to drive innovation in software
+    architecture and design. Software is oftentimes complex and its nuances can
+    be difficult to communicate efficiently. We'd like to change that.
   </p>
-  <a class="btn vscode-button" href="https://marketplace.visualstudio.com/items?itemName=appland.appmap">
-    <img src="/images/visual-studio-code-icon-blue.svg" alt=""/>
+  <a
+    class="btn vscode-button"
+    href="https://marketplace.visualstudio.com/items?itemName=appland.appmap"
+    data-event-on="click"
+    data-event-category="engagement"
+    data-event-action="view_extension_page"
+    data-event-label="appland.appmap"
+  >
+    <img src="/images/visual-studio-code-icon-blue.svg" alt="" />
     <h3>Get the AppMap extension for Visual Studio Code</h3>
   </a>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,30 @@
           gtag('js', new Date());
 
           gtag('config', 'UA-180943551-1');
+
+          document.addEventListener('DOMContentLoaded', function() {
+            var eventElements = document.querySelectorAll('[data-event-action]');
+            for (var i = 0; i < eventElements.length; ++i) {
+              var element = eventElements[i];
+              var label = element.getAttribute('data-event-label');
+              var category = element.getAttribute('data-event-category');
+              var action = element.getAttribute('data-event-action');
+              var on = element.getAttribute('data-event-on') || 'click';
+              var payload = {};
+
+              if (label) {
+                payload['event_label'] = label;
+              }
+
+              if (category) {
+                payload['event_category'] = category;
+              }
+
+              element.addEventListener(on, function() {
+                  gtag('event', action, payload);
+              });
+            }
+          });
         </script>
       {% endif %}
     </div>


### PR DESCRIPTION
Automatically bind and send GA events through data attributes. See
https://developers.google.com/analytics/devguides/collection/gtagjs/events
for more information.