### PR TITLE
add post layout to fix code gallery styling

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<div class="section-content post-content">
+  <h1>{{ page.title }}</h1>
+  <p class="post-meta">Posted {{ page.date | date_to_string }} by {{ page.author }}</p>
+  {% if page.category=="blog" %}
+    {% if page.image %}
+      <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.title }}" class="post-image">
+    {% endif %}
+    {% if page.image_url %}
+      <img src="{{ page.image_url }}" alt="{{ page.title }}" class="post-image">
+    {% endif %}
+  {% endif %}
+  {{ content }}
+</div>


### PR DESCRIPTION
add `post.html` back into `_layouts` to fix code gallery styling (was removed accidentally when transitioning blog from .org to .com)